### PR TITLE
Robert/bugfix/verifast object creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ java -cp '*' org.contract_lib.ContractChameleon # load all available classpaths 
 The additional `JAR` must have a file with the name `org.contract_lib.contract_chameleon.Adapter`
  in `src/main/ressources/META-INF/services`
 containing the full class name (including package) of the additional adapter.
-Compare the following [example](./contract-chameleon.adapter.key-provider/).
+Compare the following [example](./contract-chameleon.adapter.key.import/).
 
 ## Developing the tool
 

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
@@ -27,8 +27,11 @@ import org.contract_lib.lang.verifast.ast.VeriFastMethod;
 import org.contract_lib.lang.verifast.ast.VeriFastPredicate;
 import org.contract_lib.lang.verifast.ast.VeriFastSpec;
 import org.contract_lib.lang.verifast.ast.VeriFastClass;
+import org.contract_lib.lang.verifast.ast.VeriFastConstructor;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
+import org.contract_lib.lang.verifast.ast.VeriFastJavaExpression;
+import org.contract_lib.lang.verifast.ast.VeriFastJavaStatement;
 import org.contract_lib.lang.verifast.ast.VeriFastArgument;
 import org.contract_lib.lang.verifast.ast.VeriFastContract;
 
@@ -70,9 +73,20 @@ public class SimpleVerifastTranslator {
   private final List<String> javaSpecFiles;
   private final List<String> javaFiles;
 
+  /// Access the name of the implementation class given an class identifer.
+  private final Map<String, String> getImplementationClassName;
+
+  /// Available methods of the abstract class.
   private final Map<String, List<VeriFastMethod>> getAbstractJavaClassMethods;
+
+  /// Available methods of the implementation class.
   private final Map<String, List<VeriFastMethod>> getImplClassMethods;
+
+  /// Available methods of the java specification.
   private final Map<String, List<VeriFastMethod>> getSpecClassMethods;
+
+  /// Available constructors of the implementation class.
+  private final Map<String, List<VeriFastConstructor>> getImplClassConstructors;
 
   private final List<TermTranslation> termTranslations;
   private final List<QuantorTranslation> quantorTranslations;
@@ -84,9 +98,11 @@ public class SimpleVerifastTranslator {
     this.javaSpecFiles = new ArrayList<>();
     this.javaFiles = new ArrayList<>();
 
+    this.getImplementationClassName = new HashMap<>();
     this.getAbstractJavaClassMethods = new HashMap<>();
     this.getImplClassMethods = new HashMap<>();
     this.getSpecClassMethods = new HashMap<>();
+    this.getImplClassConstructors = new HashMap<>();
 
     this.helperTranslator = new HelperTranslator(
         this.messageManager,
@@ -180,11 +196,13 @@ public class SimpleVerifastTranslator {
     List<VeriFastPredicate> predicates = predicateTranslator.translatePredicateDef(
         name,
         abstraction.datatypeDec().constructors().get(0));
+
     List<VeriFastMethod> methods = new ArrayList<>();
 
     VeriFastClass vfc = new VeriFastClass(
         name,
         predicates,
+        new ArrayList<>(),
         methods,
         true,
         Optional.empty());
@@ -221,6 +239,7 @@ public class SimpleVerifastTranslator {
     VeriFastClass vfc = new VeriFastClass(
         name,
         predicates,
+        new ArrayList<>(),
         methods,
         true,
         Optional.empty());
@@ -239,7 +258,7 @@ public class SimpleVerifastTranslator {
     addAbstractionType(name);
     javaSpecFiles.add(directoryName + "/" + name + ".javaspec");
     results.add(file);
-    getSpecClassMethods.put(identifier, methods);
+    this.getSpecClassMethods.put(identifier, methods);
   }
 
   private void translateAbstractionImplementation(Abstraction abstraction) {
@@ -256,10 +275,12 @@ public class SimpleVerifastTranslator {
         abstraction.datatypeDec().constructors().get(0));
 
     List<VeriFastMethod> methods = new ArrayList<>();
+    List<VeriFastConstructor> constructors = new ArrayList<>();
 
     VeriFastClass vfc = new VeriFastClass(
         implName,
         predicates,
+        constructors,
         methods,
         false,
         Optional.of(name));
@@ -276,9 +297,13 @@ public class SimpleVerifastTranslator {
     System.err.println("Abstraction for: " + identifier);
 
     addAbstractionType(name);
+
     javaFiles.add(directoryName + "/" + implName + ".java");
     results.add(file);
-    getImplClassMethods.put(identifier, methods);
+
+    this.getImplementationClassName.put(identifier, implName);
+    this.getImplClassMethods.put(identifier, methods);
+    this.getImplClassConstructors.put(identifier, constructors);
   }
 
   public void translateContract(Contract contract) {
@@ -339,28 +364,39 @@ public class SimpleVerifastTranslator {
             new VeriFastExpression.Variable(NULL)))
         .ifPresent(ensuresPredicates::add);
 
-    //resultPredicate.ifPresent(ensuresExprList::add);
-    //TODO: add not null predicate for result constructor
-
     TermTranslator.VeriFastPrePostExpression expressions = termTranslator.translateContractPairs(
         requiresPredicates,
         ensuresPredicates,
         contract.pairs());
 
-    //TODO: add (expr == true) - cast from fixpoint to predicate
     requiresPredicates.add(expressions.pre());
     ensuresPredicates.add(expressions.post());
 
-    List<String> methodBody = extractor.getDefaultMethodBody(typeTranslator::getDefaultMethodBody);
+    VeriFastJavaExpression defaultBody = new VeriFastJavaExpression.SimpleStatement(
+        extractor.getDefaultMethodBody());
+
+    List<VeriFastJavaExpression> consBody = new ArrayList<>();
+    consBody.add(defaultBody);
+    consBody.add(new VeriFastJavaExpression.SimpleStatement("//@assume false;"));
+
+    List<VeriFastJavaExpression> methodBody = new ArrayList<>(List.of(defaultBody));
+
+    String implementationClass = this.getImplementationClassName.get(extractor.ownerClassIdentifier());
 
     List<VeriFastArgument> arguments = translateArguments(extractor.getArguments());
+
+    List<VeriFastJavaExpression> constructorCaller = List.of(
+        new VeriFastJavaExpression.Return(
+            new VeriFastJavaStatement.ConstructorCall(
+                new VeriFastType.VeriFastClass(implementationClass, List.of()),
+                arguments)));
 
     VeriFastContract vfContract = new VeriFastContract(
         new VeriFastExpression.Chain(requiresPredicates),
         new VeriFastExpression.Chain(ensuresPredicates));
 
+    List<VeriFastMethod> listImpl = this.getImplClassMethods.get(owner);
     if (!isStatic) {
-      List<VeriFastMethod> listImpl = this.getImplClassMethods.get(owner);
       if (listImpl != null) {
         listImpl.add(new VeriFastMethod(
             vfContract,
@@ -372,6 +408,16 @@ public class SimpleVerifastTranslator {
       }
     }
 
+    List<VeriFastConstructor> listCons = this.getImplClassConstructors.get(owner);
+    if (isStatic) {
+      if (listCons != null) {
+        listCons.add(new VeriFastConstructor(
+            vfContract,
+            arguments,
+            consBody));
+      }
+    }
+
     List<VeriFastMethod> listAbst = this.getAbstractJavaClassMethods.get(owner);
     if (listAbst != null) {
       listAbst.add(new VeriFastMethod(
@@ -380,7 +426,7 @@ public class SimpleVerifastTranslator {
           resultType,
           arguments,
           isStatic,
-          isStatic ? Optional.of(methodBody) : Optional.empty()));
+          isStatic ? Optional.of(constructorCaller) : Optional.empty()));
     }
 
     List<VeriFastMethod> listSpec = this.getSpecClassMethods.get(owner);

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
@@ -166,7 +166,7 @@ public class SimpleVerifastTranslator {
   private void addAbstractionType(String name) {
     this.typeTranslator.addTranslation(new AbstractionTranslation(
         new Sort.Type(name),
-        new VeriFastType(name)));
+        new VeriFastType.VeriFastClass(name, List.of())));
   }
 
   private void translateAbstractionJavaFile(Abstraction abstraction) {
@@ -307,10 +307,8 @@ public class SimpleVerifastTranslator {
     extractor.thisMutatableArgument()
         .ifPresent(inoutArguments::add);
 
-    //TODO: Add helper for types!!
+    //TODO: Add helper for user types!!
 
-    //TODO: split predicate translation in precond. and postconds as they have diff. available arguments
-    // - the 
     predicateTranslator.clearAvailableArguments();
 
     TermTranslator termTranslator = new TermTranslator(
@@ -334,6 +332,8 @@ public class SimpleVerifastTranslator {
         .ifPresent(ensuresPredicates::add);
 
     extractor.getReturnType()
+        .map(this.typeTranslator::translate)
+        .filter(t -> !t.isLogicType())
         .map((p) -> new VeriFastExpression.BinaryOperation("!=",
             new VeriFastExpression.Variable(RESULT_NAME),
             new VeriFastExpression.Variable(NULL)))

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
@@ -375,9 +375,7 @@ public class SimpleVerifastTranslator {
     VeriFastJavaExpression defaultBody = new VeriFastJavaExpression.SimpleStatement(
         extractor.getDefaultMethodBody());
 
-    List<VeriFastJavaExpression> consBody = new ArrayList<>();
-    consBody.add(defaultBody);
-    consBody.add(new VeriFastJavaExpression.SimpleStatement("//@assume false;"));
+    List<VeriFastJavaExpression> consBody = new ArrayList<>(List.of(defaultBody));
 
     List<VeriFastJavaExpression> methodBody = new ArrayList<>(List.of(defaultBody));
 

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/SimpleVerifastTranslator.java
@@ -57,6 +57,9 @@ import org.contract_lib.adapters.translation.quantifier.AllIntQuantorTranslation
 /// what are suitable abstractions and interfaces used in a translation.
 public class SimpleVerifastTranslator {
 
+  private static final String RESULT_NAME = "result";
+  private static final String NULL = "null";
+
   private ChameleonMessageManager messageManager;
 
   private final TypeTranslator typeTranslator;
@@ -326,10 +329,15 @@ public class SimpleVerifastTranslator {
 
     //If the return value is an abstraction, create the predicate for return 
     extractor.getReturnType()
-        .map((p) -> new Argument(p, "result"))
+        .map((p) -> new Argument(p, RESULT_NAME))
         .flatMap(p -> predicateTranslator.createPredicate(p, termTranslator, true, false))
         .ifPresent(ensuresPredicates::add);
-    //TODO: Add result != null
+
+    extractor.getReturnType()
+        .map((p) -> new VeriFastExpression.BinaryOperation("!=",
+            new VeriFastExpression.Variable(RESULT_NAME),
+            new VeriFastExpression.Variable(NULL)))
+        .ifPresent(ensuresPredicates::add);
 
     //resultPredicate.ifPresent(ensuresExprList::add);
     //TODO: add not null predicate for result constructor

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/HelperTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/HelperTranslator.java
@@ -17,9 +17,10 @@ import org.contract_lib.adapters.result.HelperFile;
 public final class HelperTranslator {
 
   private static final String HELPER_FILE = "_chameleon_help";
-  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType("boolean");
-  private static final VeriFastType GEN_LIST = new VeriFastType("list<t>");
-  private static final VeriFastType GEN_EL = new VeriFastType("t");
+  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType.VeriFastBoolean();
+  private static final VeriFastType GEN_LIST = new VeriFastType.VeriFastInduction("list",
+      List.of(new VeriFastType.VeriFastClass("t", List.of())));
+  private static final VeriFastType GEN_EL = new VeriFastType.VeriFastClass("t", List.of());
 
   public static final List<VeriFastHelper> DEFAULT_HELPER = List.of(
       new VeriFastFixpoint(
@@ -116,5 +117,4 @@ public final class HelperTranslator {
         HELPER_FILE,
         new VeriFastHelperSpecification(this.helper));
   }
-
 }

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/TypeTranslator.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/TypeTranslator.java
@@ -13,7 +13,7 @@ public final class TypeTranslator {
   private final Map<String, TypeTranslation> translations;
 
   public TypeTranslator(List<TypeTranslation> translations) {
-    this.translations = new HashMap();
+    this.translations = new HashMap<>();
     for (TypeTranslation t : translations) {
       this.translations.put(t.getClibSort().getName(), t);
     }
@@ -33,7 +33,7 @@ public final class TypeTranslator {
     if (t == null) {
       System.err.println(String.format("ERROR: Translation not found for sort: %s", sort.getName()));
       //TODO: print proper error
-      return new VeriFastType("ErrorType");
+      return new VeriFastType.VeriFastClass("ErrorType", List.of());
     } else {
       return t.getVerifastType(this, sort);
     }

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/BooleanTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/BooleanTermTranslation.java
@@ -17,7 +17,7 @@ import static org.contract_lib.adapters.translation.TermTranslation.FixpointOper
 public final record BooleanTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");
-  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType("boolean");
+  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType.VeriFastBoolean();
 
   public List<TermTranslation> getAll() {
     return List.of(

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/IntTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/IntTermTranslation.java
@@ -16,7 +16,7 @@ import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperat
 public final record IntTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_INT = new Sort.Type("Int");
-  public final static VeriFastType VERIFAST_INT = new VeriFastType("int");
+  public final static VeriFastType VERIFAST_INT = new VeriFastType.VeriFastInteger();
 
   public List<TermTranslation> getAll() {
     return List.of(

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/MapTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/MapTermTranslation.java
@@ -18,7 +18,7 @@ import static org.contract_lib.adapters.translation.TermTranslation.FixpointOper
 public final record MapTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");
-  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType("boolean");
+  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType.VeriFastBoolean();
 
   public List<TermTranslation> getAll() {
     return List.of();

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SeqTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SeqTermTranslation.java
@@ -24,10 +24,11 @@ public final record SeqTermTranslation() implements TermTranslationProvider {
   public final static Sort.Type CLIB_INT = new Sort.Type("Int");
   public final static Sort.Type CLIB_SEQ = new Sort.Type("Seq");
   public final static Sort.Type CLIB_GEN = new Sort.Type("A");
-  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType("boolean");
-  public final static VeriFastType VERIFAST_INT = new VeriFastType("int");
-  public final static VeriFastType VERIFAST_SEQ = new VeriFastType("list<A>");
-  public final static VeriFastType VERIFAST_GEN = new VeriFastType("A");
+  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType.VeriFastBoolean();
+  public final static VeriFastType VERIFAST_INT = new VeriFastType.VeriFastInteger();
+  public final static VeriFastType VERIFAST_SEQ = new VeriFastType.VeriFastInduction("list",
+      List.of(new VeriFastType.VeriFastClass("A", List.of())));
+  public final static VeriFastType VERIFAST_GEN = new VeriFastType.VeriFastClass("A", List.of());
 
   public List<TermTranslation> getAll() {
     return List.of(

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SetTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SetTermTranslation.java
@@ -17,7 +17,7 @@ import static org.contract_lib.adapters.translation.TermTranslation.FixpointOper
 public final record SetTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");
-  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType("boolean");
+  public final static VeriFastType VERIFAST_BOOLEAN = new VeriFastType.VeriFastBoolean();
 
   public List<TermTranslation> getAll() {
     return List.of();

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/quantifier/AllIntQuantorTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/quantifier/AllIntQuantorTranslation.java
@@ -26,8 +26,8 @@ public final record AllIntQuantorTranslation() implements QuantorTranslation {
 
   private static final String FORALL_INT_QUANTOR_PREDICATE_NAME = "forall_int";
   private static final String RES_SUFFIX = "_res";
-  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType("boolean");
-  private static final VeriFastType INT_TYPE = new VeriFastType("int");
+  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType.VeriFastBoolean();
+  private static final VeriFastType INT_TYPE = new VeriFastType.VeriFastInteger();
 
   @Override
   public Optional<VeriFastExpression> translate(

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/quantifier/ExistentialQuantorTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/quantifier/ExistentialQuantorTranslation.java
@@ -26,7 +26,7 @@ public final record ExistentialQuantorTranslation() implements QuantorTranslatio
 
   private static final String EXISTS_QUANTOR_PREDICATE_NAME = "exists";
   private static final String RES_SUFFIX = "_res";
-  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType("boolean");
+  private static final VeriFastType BOOLEAN_TYPE = new VeriFastType.VeriFastBoolean();
 
   @Override
   public Optional<VeriFastExpression> translate(

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/BoolTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/BoolTranslation.java
@@ -18,7 +18,7 @@ public final class BoolTranslation implements TypeTranslation {
   public VeriFastType getVerifastType(
       TypeTranslator translator,
       Sort sort) {
-    return new VeriFastType("boolean");
+    return new VeriFastType.VeriFastBoolean();
   }
 
   public List<VeriFastExpression> getHelper() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/IntTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/IntTranslation.java
@@ -18,7 +18,7 @@ public final class IntTranslation implements TypeTranslation {
   public VeriFastType getVerifastType(
       TypeTranslator translator,
       Sort sort) {
-    return new VeriFastType("int");
+    return new VeriFastType.VeriFastInteger();
   }
 
   public List<VeriFastExpression> getHelper() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/MapTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/MapTranslation.java
@@ -23,9 +23,10 @@ public final class MapTranslation implements TypeTranslation {
     if (inner.size() != 2) {
       System.err.println("two parameter for map expected");
     }
-    return new VeriFastType(
-        String.format("map<pair<%s, %s>>", translator.translate(inner.get(0)).name(),
-            translator.translate(inner.get(1)).name()));
+    return new VeriFastType.VeriFastInduction("list", List.of(
+        new VeriFastType.VeriFastInduction("pair", List.of(
+            translator.translate(inner.get(0)),
+            translator.translate(inner.get(1))))));
   }
 
   public List<VeriFastExpression> getHelper() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SeqTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SeqTranslation.java
@@ -22,7 +22,7 @@ public final class SeqTranslation implements TypeTranslation {
     if (inner.size() != 1) {
       System.err.println("One parameter for Seq expected");
     }
-    return new VeriFastType(String.format("list<%s>", translator.translate(inner.get(0)).name()));
+    return new VeriFastType.VeriFastInduction("list", List.of(translator.translate(inner.get(0))));
   }
 
   public List<VeriFastExpression> getHelper() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SetTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SetTranslation.java
@@ -22,7 +22,7 @@ public final class SetTranslation implements TypeTranslation {
     if (inner.size() != 1) {
       System.err.println("one parameter for Ref expected");
     }
-    return new VeriFastType(String.format("list<%s>", translator.translate(inner.get(0)).name()));
+    return new VeriFastType.VeriFastInduction("list", List.of(translator.translate(inner.get(0))));
   }
 
   public List<VeriFastExpression> getHelper() {

--- a/contract-chameleon.lang.contract_lib.tools/src/main/java/org/contract_lib/lang/contract_lib/tools/JavaMethodSignaturExtractor.java
+++ b/contract-chameleon.lang.contract_lib.tools/src/main/java/org/contract_lib/lang/contract_lib/tools/JavaMethodSignaturExtractor.java
@@ -18,11 +18,10 @@ import org.contract_lib.lang.contract_lib.ast.Argument;
 
 public final class JavaMethodSignaturExtractor {
 
-  private static final String DEFAULT_RETURN_IDENTIFIER = "result"; 
-  private static final String DEFAULT_THIS_IDENTIFIER = "this"; 
-  private static final String DOT = "."; 
+  private static final String DEFAULT_RETURN_IDENTIFIER = "result";
+  private static final String DEFAULT_THIS_IDENTIFIER = "this";
+  private static final String DOT = ".";
   private static final String TODO_MESSAGE = "//TODO: Implement method '%s'.";
-  private static final String RETURN_COMMAND = "return %s;";
 
   private String contractIdentifier;
   private String methodName;
@@ -30,8 +29,8 @@ public final class JavaMethodSignaturExtractor {
   private Optional<Sort> ownerSort;
   private boolean isStatic;
   private boolean readOnlyThis;
-  private final List<Argument> arguments; 
-  private final List<Argument> inoutArguments; 
+  private final List<Argument> arguments;
+  private final List<Argument> inoutArguments;
   private final List<Argument> inArguments;
   private Optional<Sort> returnType;
 
@@ -39,21 +38,20 @@ public final class JavaMethodSignaturExtractor {
   private final Set<String> fieldIdentifier;
 
   public JavaMethodSignaturExtractor(
-    Contract contract,
-    ChameleonMessageManager messageManager
-  ) {
+      Contract contract,
+      ChameleonMessageManager messageManager) {
     this.isStatic = true;
-    this.fieldIdentifier = new HashSet();
-    this.arguments = new ArrayList();
-    this.inoutArguments = new ArrayList();
-    this.inArguments = new ArrayList();
+    this.fieldIdentifier = new HashSet<>();
+    this.arguments = new ArrayList<>();
+    this.inoutArguments = new ArrayList<>();
+    this.inArguments = new ArrayList<>();
     this.returnType = Optional.empty();
     this.contractIdentifier = contract.identifier().identifier();
 
     Optional<String> className = extractName(contractIdentifier);
     contract.formals().stream().forEachOrdered(this::handleFormal);
 
-    className.ifPresent((cn)->{
+    className.ifPresent((cn) -> {
       ownerClassIdentifier = cn;
     });
 
@@ -62,21 +60,8 @@ public final class JavaMethodSignaturExtractor {
     }
   }
 
-  public List<String> getDefaultMethodBody(Function<Sort, String> defaultValueProvider) {
-    Optional<String> translation = returnType
-      .map(defaultValueProvider);
-
-
-    List<String> returnValue = translation
-      .map((s) -> List.of(
-        String.format(TODO_MESSAGE, contractIdentifier),
-        String.format(RETURN_COMMAND, s))
-      )
-      .orElseGet(() -> List.of(
-        String.format(TODO_MESSAGE, contractIdentifier)
-      ));
-
-    return returnValue;
+  public String getDefaultMethodBody() {
+    return String.format(TODO_MESSAGE, contractIdentifier);
   }
 
   public String methodName() {
@@ -96,15 +81,15 @@ public final class JavaMethodSignaturExtractor {
   }
 
   public List<Argument> getArguments() {
-    return new ArrayList(this.arguments);
+    return new ArrayList<>(this.arguments);
   }
 
   public List<Argument> inoutArguments() {
-    return new ArrayList(this.inoutArguments);
+    return new ArrayList<>(this.inoutArguments);
   }
 
   public List<Argument> inArguments() {
-    return new ArrayList(this.inArguments);
+    return new ArrayList<>(this.inArguments);
   }
 
   public Optional<Argument> thisReadOnlyArgument() {
@@ -112,15 +97,16 @@ public final class JavaMethodSignaturExtractor {
       return Optional.empty();
     } else {
       return this.ownerSort
-        .map((s) -> new Argument(s, DEFAULT_THIS_IDENTIFIER));
+          .map((s) -> new Argument(s, DEFAULT_THIS_IDENTIFIER));
     }
   }
+
   public Optional<Argument> thisMutatableArgument() {
     if (isStatic || this.readOnlyThis) {
       return Optional.empty();
     } else {
       return this.ownerSort
-        .map((s) -> new Argument(s, DEFAULT_THIS_IDENTIFIER));
+          .map((s) -> new Argument(s, DEFAULT_THIS_IDENTIFIER));
     }
   }
 
@@ -145,6 +131,7 @@ public final class JavaMethodSignaturExtractor {
       System.err.println("ERROR: There must only be one out parameter named `result`");
     }
   }
+
   private void addParameter(Formal f, List<Argument> toList) {
     String name = f.identifier().identifier();
     if (name.equals(DEFAULT_RETURN_IDENTIFIER)) {
@@ -155,6 +142,7 @@ public final class JavaMethodSignaturExtractor {
       toList.add(new Argument(f.sort(), name));
     }
   }
+
   private void handlThisParameter(Formal formal) {
     if (this.isStatic) {
       //TODO: Add conversion from type to class identifier
@@ -173,6 +161,7 @@ public final class JavaMethodSignaturExtractor {
       System.err.println("ERROR: Parameter with name `this` is used multiple times.");
     }
   }
+
   private void handleInoutParameter(Formal formal) {
     if (formal.identifier().identifier().equals(DEFAULT_THIS_IDENTIFIER)) {
       handlThisParameter(formal);
@@ -180,6 +169,7 @@ public final class JavaMethodSignaturExtractor {
       addParameter(formal, this.inoutArguments);
     }
   }
+
   private void handleInParameter(Formal formal) {
     if (formal.identifier().identifier().equals(DEFAULT_THIS_IDENTIFIER)) {
       handlThisParameter(formal);

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastClass.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastClass.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 public record VeriFastClass(
     String name,
     List<VeriFastPredicate> predicates,
+    List<VeriFastConstructor> constructors,
     List<VeriFastMethod> methods,
     boolean isAbstract,
-    Optional<String> implFrom
-) {
+    Optional<String> implFrom) {
 }

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastComment.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastComment.java
@@ -1,0 +1,42 @@
+package org.contract_lib.lang.verifast.ast;
+
+import java.util.function.Function;
+
+public interface VeriFastComment {
+
+  public <R> R perform(
+      Function<Inline, R> inline,
+      Function<Multiline, R> multiline,
+      Function<EndLine, R> endLine);
+
+  public record Inline(String commentBody) implements VeriFastComment {
+
+    @Override
+    public <R> R perform(
+        Function<Inline, R> inline,
+        Function<Multiline, R> multiline,
+        Function<EndLine, R> endLine) {
+      return inline.apply(this);
+    }
+  }
+
+  public record Multiline(String commentBody) implements VeriFastComment {
+    @Override
+    public <R> R perform(
+        Function<Inline, R> inline,
+        Function<Multiline, R> multiline,
+        Function<EndLine, R> endLine) {
+      return multiline.apply(this);
+    }
+  }
+
+  public record EndLine(String commentBody) implements VeriFastComment {
+    @Override
+    public <R> R perform(
+        Function<Inline, R> inline,
+        Function<Multiline, R> multiline,
+        Function<EndLine, R> endLine) {
+      return endLine.apply(this);
+    }
+  }
+}

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastConstructor.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastConstructor.java
@@ -1,0 +1,9 @@
+package org.contract_lib.lang.verifast.ast;
+
+import java.util.List;
+
+public record VeriFastConstructor(
+    VeriFastContract contract,
+    List<VeriFastArgument> arguments,
+    List<VeriFastJavaExpression> body) {
+}

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastJavaExpression.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastJavaExpression.java
@@ -1,0 +1,49 @@
+package org.contract_lib.lang.verifast.ast;
+
+import java.util.function.Function;
+
+public interface VeriFastJavaExpression {
+
+
+  public <R> R perform(
+      Function<Standard, R> standardExpression,
+      Function<Return, R> returnExpression,
+      Function<SimpleStatement, R> simpleStatement);
+
+
+  public record Standard(
+      VeriFastJavaStatement statement) implements VeriFastJavaExpression {
+
+    @Override
+      public <R> R perform(
+      Function<Standard, R> standardExpression,
+      Function<Return, R> returnExpression,
+      Function<SimpleStatement, R> simpleStatement) { 
+      return standardExpression.apply(this);
+    }
+  }
+  public record Return(
+      VeriFastJavaStatement statement) implements VeriFastJavaExpression {
+
+    @Override
+      public <R> R perform(
+        Function<Standard, R> standard,
+        Function<Return, R> returnExpression,
+        Function<SimpleStatement, R> simpleStatement) { 
+      return returnExpression.apply(this);
+    }
+  }
+
+    public record SimpleStatement(
+      String statement 
+    ) implements VeriFastJavaExpression {
+
+      @Override
+      public <R> R perform(
+      Function<Standard, R> standardExpression,
+      Function<Return, R> returnExpression,
+      Function<SimpleStatement, R> simpleStatement) { 
+          return simpleStatement.apply(this);
+      }
+    }
+}

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastJavaStatement.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastJavaStatement.java
@@ -1,0 +1,32 @@
+package org.contract_lib.lang.verifast.ast;
+
+import java.util.List;
+import java.util.function.Function;
+
+public interface VeriFastJavaStatement {
+
+  public <R> R perform(
+      Function<ConstructorCall, R> constructor,
+      Function<DefaultValue, R> defaultValue);
+
+  public record ConstructorCall(
+      VeriFastType classType,
+      List<VeriFastArgument> arguments) implements VeriFastJavaStatement {
+
+    @Override
+    public <R> R perform(
+        Function<ConstructorCall, R> constructor,
+        Function<DefaultValue, R> defaultValue) {
+      return constructor.apply(this);
+    }
+  }
+
+  public record DefaultValue(VeriFastType type) implements VeriFastJavaStatement {
+    @Override
+    public <R> R perform(
+        Function<ConstructorCall, R> constructor,
+        Function<DefaultValue, R> defaultValue) {
+      return defaultValue.apply(this);
+    }
+  }
+}

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastMethod.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastMethod.java
@@ -9,7 +9,7 @@ public record VeriFastMethod(
     Optional<VeriFastType> resultType,
     List<VeriFastArgument> arguments,
     boolean isStatic,
-    Optional<List<String>> body //if no body method is abstract
+    Optional<List<VeriFastJavaExpression>> body //if no body method is abstract
 ) {
 
 }

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastType.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/ast/VeriFastType.java
@@ -1,5 +1,118 @@
 package org.contract_lib.lang.verifast.ast;
 
-public record VeriFastType(
-  String name
-) {} 
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public interface VeriFastType {
+
+  <R> R perform(
+      Function<VeriFastBoolean, R> booleanType,
+      Function<VeriFastInteger, R> integerType,
+      Function<VeriFastClass, R> classType,
+      Function<VeriFastInduction, R> inductionType);
+
+  boolean isLogicType();
+
+  String getName();
+
+  public record VeriFastBoolean() implements VeriFastType {
+
+    @Override
+    public <R> R perform(
+        Function<VeriFastBoolean, R> booleanType,
+        Function<VeriFastInteger, R> integerType,
+        Function<VeriFastClass, R> classType,
+        Function<VeriFastInduction, R> inductionType) {
+      return booleanType.apply(this);
+    }
+
+    @Override
+    public boolean isLogicType() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "boolean";
+    }
+  }
+
+  public record VeriFastInteger() implements VeriFastType {
+
+    @Override
+    public <R> R perform(
+        Function<VeriFastBoolean, R> booleanType,
+        Function<VeriFastInteger, R> integerType,
+        Function<VeriFastClass, R> classType,
+        Function<VeriFastInduction, R> inductionType) {
+      return integerType.apply(this);
+    }
+
+    @Override
+    public boolean isLogicType() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "int";
+    }
+  }
+
+  public record VeriFastClass(String name, List<VeriFastType> genericArguments) implements VeriFastType {
+
+    @Override
+    public <R> R perform(
+        Function<VeriFastBoolean, R> booleanType,
+        Function<VeriFastInteger, R> integerType,
+        Function<VeriFastClass, R> classType,
+        Function<VeriFastInduction, R> inductionType) {
+      return classType.apply(this);
+    }
+
+    @Override
+    public boolean isLogicType() {
+      return false;
+    }
+
+    @Override
+    public String getName() {
+      if (!genericArguments.isEmpty()) {
+        return this.name + "<" + genericArguments.stream()
+            .map(VeriFastType::getName)
+            .collect(Collectors.joining(", "))
+            + ">";
+      }
+      return this.name;
+    }
+  }
+
+  public record VeriFastInduction(String name, List<VeriFastType> genericArguments) implements VeriFastType {
+
+    @Override
+    public <R> R perform(
+        Function<VeriFastBoolean, R> booleanType,
+        Function<VeriFastInteger, R> integerType,
+        Function<VeriFastClass, R> classType,
+        Function<VeriFastInduction, R> inductionType) {
+      return inductionType.apply(this);
+    }
+
+    @Override
+    public boolean isLogicType() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      if (!genericArguments.isEmpty()) {
+        return this.name + "<" + genericArguments.stream()
+            .map(VeriFastType::getName)
+            .collect(Collectors.joining(", "))
+            + ">";
+      }
+      return this.name;
+    }
+  }
+}

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/tools/VeriFastPrinter.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/tools/VeriFastPrinter.java
@@ -14,11 +14,14 @@ import org.contract_lib.lang.verifast.ast.VeriFastClass;
 import org.contract_lib.lang.verifast.ast.VeriFastContract;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastMethod;
+import org.contract_lib.lang.verifast.ast.VeriFastConstructor;
 
 import org.contract_lib.lang.verifast.ast.VeriFastHelperSpecification;
 import org.contract_lib.lang.verifast.ast.VeriFastHelper;
 import org.contract_lib.lang.verifast.ast.VeriFastInduction;
 import org.contract_lib.lang.verifast.ast.VeriFastInductionConstructor;
+import org.contract_lib.lang.verifast.ast.VeriFastJavaExpression;
+import org.contract_lib.lang.verifast.ast.VeriFastJavaStatement;
 import org.contract_lib.lang.verifast.ast.VeriFastFixpoint;
 
 public class VeriFastPrinter {
@@ -63,6 +66,9 @@ public class VeriFastPrinter {
   private static final String CURLY_BRACKET_OPEN = "{";
   private static final String CURLY_BRACKET_CLOSE = "}";
 
+  /// The name of the class, which content is printed at the moment.
+  private String className;
+
   public VeriFastPrinter(Writer writer) {
     this.writer = writer;
     this.indentation = 0;
@@ -100,8 +106,11 @@ public class VeriFastPrinter {
     });
     print(SPACE);
     printBlock(() -> {
+      this.className = vfClass.name();
       printNewLine();
       printList(vfClass.predicates(), () -> printNewLine(), this::printVeriFastPredicate);
+      printNewLine();
+      printList(vfClass.constructors(), () -> printNewLine(), this::printVeriFastConstructor);
       printNewLine();
       printList(vfClass.methods(), () -> printNewLine(), this::printVeriFastMethod);
     });
@@ -119,6 +128,24 @@ public class VeriFastPrinter {
     print(BRACKET_CLOSE);
     print(SEMICOLON);
     printNewLine();
+  }
+
+  public void printVeriFastConstructor(VeriFastConstructor cons) {
+    printIndentation();
+    print(this.className);
+    print(BRACKET_OPEN);
+    printColonList(cons.arguments(), this::printVeriFastArgument);
+    print(BRACKET_CLOSE);
+    printNewLine();
+    printVeriFastContract(cons.contract());
+    printIndentation();
+    printBlock(() -> {
+      for (VeriFastJavaExpression vfExpr : cons.body()) {
+        printIndentation();
+        printJavaExpr(vfExpr);
+        printNewLine();
+      }
+    });
   }
 
   public void printVeriFastType(VeriFastType type) {
@@ -151,9 +178,9 @@ public class VeriFastPrinter {
       printVeriFastContract(method.contract());
       printIndentation();
       printBlock(() -> {
-        for (String s : method.body().get()) {
+        for (VeriFastJavaExpression expr : method.body().get()) {
           printIndentation();
-          print(s);
+          printJavaExpr(expr);
           printNewLine();
         }
       });
@@ -183,9 +210,67 @@ public class VeriFastPrinter {
     printNewLine();
   }
 
+  // MARK: - Java Expressions
+
+  public void printJavaExpr(VeriFastJavaExpression expression) {
+    expression.<Void>perform(
+        this::printJavaExpressionStandard,
+        this::printJavaExpressionReturn,
+        this::printJavaExpressionSimpleStatement
+    );
+  }
+
+  public Void printJavaExpressionStandard(VeriFastJavaExpression.Standard simpleStatement) {
+    printJavaStatement(simpleStatement.statement());
+    print(SEMICOLON);
+    return null;
+  }
+
+  public Void printJavaExpressionReturn(VeriFastJavaExpression.Return returnExpression) {
+    print(RETURN);
+    print(SPACE);
+    printJavaStatement(returnExpression.statement());
+    print(SEMICOLON);
+    return null;
+  }
+
+  public Void printJavaExpressionSimpleStatement(VeriFastJavaExpression.SimpleStatement simpleStatement) {
+    print(simpleStatement.statement());
+    return null;
+  }
+
+  // MARK: - Java Statements
+
+  public void printJavaStatement(VeriFastJavaStatement statement) {
+    statement.<Void>perform(
+      this::printConstructorCall,
+      this::printDefaultStatment
+    );
+  }
+
+  public Void printConstructorCall(VeriFastJavaStatement.ConstructorCall consCall) {
+    printVeriFastType(consCall.classType());
+    print(BRACKET_OPEN);
+    printColonList(consCall.arguments(), this::printVeriFastArgumentCall);
+    print(BRACKET_CLOSE);
+    return null;
+  }
+
+  public Void printDefaultStatment(VeriFastJavaStatement.DefaultValue defaultValue) {
+    print("defaultValue.type");
+    System.err.println("ERROR: Default value for type printer not supported yet.");
+    return null;
+  }
+
+  // MARK: - Helper
+
   public void printVeriFastArgument(VeriFastArgument argument) {
     printVeriFastType(argument.type());
     print(SPACE);
+    print(argument.name());
+  }
+
+  public void printVeriFastArgumentCall(VeriFastArgument argument) {
     print(argument.name());
   }
 

--- a/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/tools/VeriFastPrinter.java
+++ b/contract-chameleon.lang.verifast/src/main/java/org/contract_lib/lang/verifast/tools/VeriFastPrinter.java
@@ -21,7 +21,6 @@ import org.contract_lib.lang.verifast.ast.VeriFastInduction;
 import org.contract_lib.lang.verifast.ast.VeriFastInductionConstructor;
 import org.contract_lib.lang.verifast.ast.VeriFastFixpoint;
 
-
 public class VeriFastPrinter {
 
   private static final int INDENTATION_STEPS = 4;
@@ -102,7 +101,7 @@ public class VeriFastPrinter {
     print(SPACE);
     printBlock(() -> {
       printNewLine();
-      printList(vfClass.predicates(),() -> printNewLine(), this::printVeriFastPredicate);
+      printList(vfClass.predicates(), () -> printNewLine(), this::printVeriFastPredicate);
       printNewLine();
       printList(vfClass.methods(), () -> printNewLine(), this::printVeriFastMethod);
     });
@@ -123,7 +122,7 @@ public class VeriFastPrinter {
   }
 
   public void printVeriFastType(VeriFastType type) {
-    print(type.name());
+    print(type.getName());
   }
 
   public void printVeriFastMethod(VeriFastMethod method) {
@@ -152,7 +151,7 @@ public class VeriFastPrinter {
       printVeriFastContract(method.contract());
       printIndentation();
       printBlock(() -> {
-        for(String s : method.body().get()) {
+        for (String s : method.body().get()) {
           printIndentation();
           print(s);
           printNewLine();
@@ -192,27 +191,25 @@ public class VeriFastPrinter {
 
   public void printVeriFastExpression(VeriFastExpression expr) {
     expr.<Void>perform(
-      this::printVeriFastExpressionChain,
-      this::printVeriFastExpressionBoolValue,
-      this::printVeriFastExpressionIntegerValue,
-      this::printVeriFastExpressionPredicate,
-      this::printVeriFastExpressionVariable,
-      this::printVeriFastExpressionVariableAssignment,
-      this::printVeriFastExpressionBinaryOperation,
-      this::printVeriFastFixpoint
-    );
+        this::printVeriFastExpressionChain,
+        this::printVeriFastExpressionBoolValue,
+        this::printVeriFastExpressionIntegerValue,
+        this::printVeriFastExpressionPredicate,
+        this::printVeriFastExpressionVariable,
+        this::printVeriFastExpressionVariableAssignment,
+        this::printVeriFastExpressionBinaryOperation,
+        this::printVeriFastFixpoint);
   }
 
   public Void printVeriFastExpressionChain(VeriFastExpression.Chain expr) {
     printList(
-      expr.expressions(),
-      () -> {
-        print(SPACE);
-        print(EXPRESSION_CHAIN_JOIN);
-        print(SPACE);
-      },
-      this::printVeriFastExpression
-    );
+        expr.expressions(),
+        () -> {
+          print(SPACE);
+          print(EXPRESSION_CHAIN_JOIN);
+          print(SPACE);
+        },
+        this::printVeriFastExpression);
     return null;
   }
 
@@ -261,6 +258,7 @@ public class VeriFastPrinter {
     print(BRACKET_CLOSE);
     return null;
   }
+
   public Void printVeriFastFixpoint(VeriFastExpression.Fixpoint expr) {
     print(expr.operation());
     print(BRACKET_OPEN);
@@ -270,7 +268,6 @@ public class VeriFastPrinter {
   }
 
   // - Helper Definition
-  
 
   public void printVeriFastHelperSpecification(VeriFastHelperSpecification spec) {
     print(VERIFAST_OPEN_BLOCK);
@@ -278,10 +275,9 @@ public class VeriFastPrinter {
     printNewLine();
 
     printList(
-      spec.definitions(),
-      () -> printNewLine(),
-      this::printVeriFastHelperDefinition
-    );
+        spec.definitions(),
+        () -> printNewLine(),
+        this::printVeriFastHelperDefinition);
 
     printNewLine();
     print(VERIFAST_CLOSE_BLOCK);
@@ -291,10 +287,9 @@ public class VeriFastPrinter {
 
   public Void printVeriFastHelperDefinition(VeriFastHelper definition) {
     return definition.perform(
-      this::printVeriFastInduction,
-      this::printVeriFastPredicateDefinition,
-      this::printVeriFastFixpoint
-    );
+        this::printVeriFastInduction,
+        this::printVeriFastPredicateDefinition,
+        this::printVeriFastFixpoint);
   }
 
   public Void printVeriFastPredicateDefinition(VeriFastPredicate definition) {
@@ -351,10 +346,13 @@ public class VeriFastPrinter {
     print(DEFINITION_OPERATOR);
     print(SPACE);
     printList(
-      definition.constructors(),
-      () -> {print(SPACE);print(CONSTRUCTOR_OPERATOR); print(SPACE); },
-      this::printVeriFastInductionConstructor
-    );
+        definition.constructors(),
+        () -> {
+          print(SPACE);
+          print(CONSTRUCTOR_OPERATOR);
+          print(SPACE);
+        },
+        this::printVeriFastInductionConstructor);
     print(SEMICOLON);
     return null;
   }
@@ -373,6 +371,7 @@ public class VeriFastPrinter {
   private interface Block {
     void content();
   }
+
   @FunctionalInterface
   private interface Separator {
     void print();
@@ -415,7 +414,7 @@ public class VeriFastPrinter {
     }
     T t = i.next();
     consumer.accept(t);
-    
+
     while (i.hasNext()) {
       t = i.next();
       separator.print();

--- a/tests.integration/export/theories/FiniteMap.clib
+++ b/tests.integration/export/theories/FiniteMap.clib
@@ -27,13 +27,15 @@
 (define-contract example_test_map.MapWrapper.initValue
   (
    (result (out MapWrapper))
+   (v (in Int))
+   (w (in Int))
    )
   ((
     true
     (and 
-      (= (a result) (map.singleton 0 0))
-      (= (b result) (map.singleton 0 0))
-      (= (c result) (map.singleton 0 0))
+      (= (a result) (map.singleton v w))
+      (= (b result) (map.singleton v w))
+      (= (c result) (map.singleton v w))
     )
   ))
 )


### PR DESCRIPTION
- Add `result != null` to verifast constructor
- Add `result != null` for  out-arguments
-  Better constructor support for verifast export translations

Discussion about the necessity of `@assume false` in constructor of applicant?