### PR TITLE
Robert/extension/maven publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,71 @@
+plugins {
+    // Used to create a singel jar
+    id("com.gradleup.shadow") version "9.0.0-rc1"
+
+    id 'application'
+    id 'maven-publish'
+}
+
+group = 'org.contract_lib'
+version = '1.0.0-SNAPSHOT' // <--- 2. MUST end in '-SNAPSHOT' for Maven to treat it as such
+
+publishing {
+    publications {
+        standard(MavenPublication) {
+            from components.shadow
+        }
+    }
+}
+
+shadowJar {
+    archiveClassifier.set("exe")
+    mergeServiceFiles()
+}
+
+distZip {
+    archiveBaseName.set("contract-chameleon")
+}
+
+repositories {
+    // Use Maven Central for resolving dependencies.
+    mavenLocal()
+    mavenCentral()
+
+    maven {
+        url = uri('https://s01.oss.sonatype.org/content/repositories/snapshots')
+    }
+}
+
+dependencies {
+    runtimeOnly project(":contract-chameleon.cl")
+
+    // Add adapters to the final jar, might be still extended through classpath in `java -cp adapters/* org.contractlib.contract_chameleon.ContractChameleon`
+    runtimeOnly project(":contract-chameleon.adapter.key.export")
+    runtimeOnly project(":contract-chameleon.adapter.verifast.export")
+    runtimeOnly project(":contract-chameleon.adapter.key.import")
+    runtimeOnly project(":contract-chameleon.adapter.help")
+}
+
+// Apply a specific Java toolchain to ease working on different environments.
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+application {
+    // Define the main class for the application.
+    mainClass = 'org.contract_lib.ContractChameleon'
+}
+
+jar {
+  manifest {
+    attributes 'Main-Class': application.mainClass
+  }
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,11 @@
-
 plugins {
-    id 'com.gradleup.shadow' version "9.3.1"
-
     id 'application'
     id 'maven-publish'
+    id 'com.gradleup.shadow' version "9.3.1"
 }
 
 group = 'org.contract_lib'
 version = '1.0.0-SNAPSHOT' // <--- 2. MUST end in '-SNAPSHOT' for Maven to treat it as such
-
-def adapterProjects = [
-    ":contract-chameleon.adapter.help",
-    ":contract-chameleon.adapter.key.export",
-    ":contract-chameleon.adapter.verifast.export",
-    ":contract-chameleon.adapter.key.import",
-]
 
 repositories {
     mavenLocal()
@@ -25,21 +16,22 @@ repositories {
     }
 }
 
-shadowJar {
-  mergeServiceFiles()
-}
-
 distZip {
     archiveBaseName.set("contract-chameleon")
 }
 
 dependencies {
-    runtimeOnly project(":contract-chameleon.cl")
+  runtimeOnly project(":contract-chameleon.cl")
 
-    // Add adapters to the final jar, might be still extended through classpath in `java -cp adapters/* org.contractlib.contract_chameleon.ContractChameleon`
-    adapterProjects.each { 
-      runtimeOnly project(it)
-    }
+  // How to add adapters from different repositories to the build
+  //runtimeOnly 'org.tool:adapter-extension:1.0.0-SNAPSHOT'
+  //runtimeOnly 'org.tool.b:adapter-extension-b:1.0.0-SNAPSHOT'
+  
+  // adapters from this repository
+  runtimeOnly project(":contract-chameleon.adapter.help")
+  runtimeOnly project(":contract-chameleon.adapter.key.export")
+  runtimeOnly project(":contract-chameleon.adapter.verifast.export")
+  runtimeOnly project(":contract-chameleon.adapter.key.import")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -62,32 +54,49 @@ jar {
   }
 }
 
-task pureShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
 
-    archiveClassifier.set("pure")
-    mergeServiceFiles()
-    configurations = project.configurations.named('runtimeClasspath').map { [it] }
-
-    manifest.from tasks.jar.manifest
-
-    // Removes all dependencies of the base distribution
-    dependencies {
-      adapterProjects.each { 
-          exclude(dependency(it))
-      }
-    }
+shadowJar {
+  
+  description ="Create a combined JAR of project and runtime dependencies with the adapters"
+  // Procedure to merge the service files
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
+  mergeServiceFiles()
+  filesMatching('META-INF/services/**') {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
+  }
 }
 
-tasks.assemble.dependsOn pureShadowJar
-tasks.assemble.dependsOn shadowJar
+task lightShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+
+  description = "Create a combined JAR of project and runtime dependencies without the adapters"
+
+  // Procedure to merge the service files
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
+  mergeServiceFiles()
+  filesMatching('META-INF/services/**') {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
+  }
+
+  archiveClassifier.set("light")
+  configurations = project.configurations.named('runtimeClasspath').map { [it] }
+
+  manifest.from tasks.jar.manifest
+  dependencies {
+    exclude(project(":contract-chameleon.adapter.key.export"))
+    exclude(project(":contract-chameleon.adapter.key.import"))
+    exclude(project(":contract-chameleon.adapter.verifast.export"))
+  }
+}
+
+assemble.dependsOn lightShadowJar 
 
 publishing {
-    publications {
-        shadow(MavenPublication) {
-            from components.shadow
+  publications {
+    shadow(MavenPublication) {
+      from components.shadow
 
-            artifact(pureShadowJar)
-        }
+      artifact(lightShadowJar)
     }
+  }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
+
 plugins {
-    // Used to create a singel jar
-    id("com.gradleup.shadow") version "9.0.0-rc1"
+    id 'com.gradleup.shadow' version "9.3.1"
 
     id 'application'
     id 'maven-publish'
@@ -9,25 +9,14 @@ plugins {
 group = 'org.contract_lib'
 version = '1.0.0-SNAPSHOT' // <--- 2. MUST end in '-SNAPSHOT' for Maven to treat it as such
 
-publishing {
-    publications {
-        standard(MavenPublication) {
-            from components.shadow
-        }
-    }
-}
-
-shadowJar {
-    archiveClassifier.set("exe")
-    mergeServiceFiles()
-}
-
-distZip {
-    archiveBaseName.set("contract-chameleon")
-}
+def adapterProjects = [
+    ":contract-chameleon.adapter.help",
+    ":contract-chameleon.adapter.key.export",
+    ":contract-chameleon.adapter.verifast.export",
+    ":contract-chameleon.adapter.key.import",
+]
 
 repositories {
-    // Use Maven Central for resolving dependencies.
     mavenLocal()
     mavenCentral()
 
@@ -36,14 +25,21 @@ repositories {
     }
 }
 
+shadowJar {
+  mergeServiceFiles()
+}
+
+distZip {
+    archiveBaseName.set("contract-chameleon")
+}
+
 dependencies {
     runtimeOnly project(":contract-chameleon.cl")
 
     // Add adapters to the final jar, might be still extended through classpath in `java -cp adapters/* org.contractlib.contract_chameleon.ContractChameleon`
-    runtimeOnly project(":contract-chameleon.adapter.key.export")
-    runtimeOnly project(":contract-chameleon.adapter.verifast.export")
-    runtimeOnly project(":contract-chameleon.adapter.key.import")
-    runtimeOnly project(":contract-chameleon.adapter.help")
+    adapterProjects.each { 
+      runtimeOnly project(it)
+    }
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -51,15 +47,12 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
-}
 
-java {
     withJavadocJar()
     withSourcesJar()
 }
 
 application {
-    // Define the main class for the application.
     mainClass = 'org.contract_lib.ContractChameleon'
 }
 
@@ -67,5 +60,34 @@ jar {
   manifest {
     attributes 'Main-Class': application.mainClass
   }
+}
+
+task pureShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+
+    archiveClassifier.set("pure")
+    mergeServiceFiles()
+    configurations = project.configurations.named('runtimeClasspath').map { [it] }
+
+    manifest.from tasks.jar.manifest
+
+    // Removes all dependencies of the base distribution
+    dependencies {
+      adapterProjects.each { 
+          exclude(dependency(it))
+      }
+    }
+}
+
+tasks.assemble.dependsOn pureShadowJar
+tasks.assemble.dependsOn shadowJar
+
+publishing {
+    publications {
+        shadow(MavenPublication) {
+            from components.shadow
+
+            artifact(pureShadowJar)
+        }
+    }
 }
 

--- a/contract-chameleon.adapter.help/build.gradle
+++ b/contract-chameleon.adapter.help/build.gradle
@@ -4,10 +4,14 @@ plugins {
 
 repositories {
     // Use Maven Central for resolving dependencies.
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+
     implementation project(":contract-chameleon.core")
     implementation project(":contract-chameleon.error")
 

--- a/contract-chameleon.adapter.help/src/main/java/org/contract_lib/adapters/Help.java
+++ b/contract-chameleon.adapter.help/src/main/java/org/contract_lib/adapters/Help.java
@@ -3,6 +3,9 @@ package org.contract_lib.adapters;
 import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.AdapterMap;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class Help extends Adapter implements HelpMessage {
 
   private static String ADAPTER_NAME = "help";

--- a/contract-chameleon.adapter.help/src/main/resources/META-INF/services/org.contract_lib.adapters.HelpMessage
+++ b/contract-chameleon.adapter.help/src/main/resources/META-INF/services/org.contract_lib.adapters.HelpMessage
@@ -1,1 +1,0 @@
-org.contract_lib.adapters.Help

--- a/contract-chameleon.adapter.help/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
+++ b/contract-chameleon.adapter.help/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
@@ -1,1 +1,0 @@
-org.contract_lib.adapters.Help

--- a/contract-chameleon.adapter.key.export/build.gradle
+++ b/contract-chameleon.adapter.key.export/build.gradle
@@ -14,6 +14,9 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+
     implementation project(":contract-chameleon.core")
     implementation project(":contract-chameleon.error")
     implementation project(":contract-chameleon.lang.contract_lib")

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/KeyApplicant.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/KeyApplicant.java
@@ -4,13 +4,16 @@ import java.io.IOException;
 import java.util.List;
 import java.nio.file.Path;
 
+import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.ExportAdapter;
 import org.contract_lib.contract_chameleon.error.ChameleonMessageManager;
 
 import org.contract_lib.lang.contract_lib.ast.ContractLibAst;
 import org.contract_lib.lang.contract_lib.generator.ContractLibGenerator;
 
-//TODO: Subclase the correct export adapter
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class KeyApplicant extends ExportAdapter {
 
   public String defaultOutputDir() {
@@ -23,8 +26,7 @@ public final class KeyApplicant extends ExportAdapter {
 
   public List<TranslationResult> perform(
       List<Path> sourceFiles,
-      ChameleonMessageManager messageManager
-    ) throws IOException {
+      ChameleonMessageManager messageManager) throws IOException {
 
     //TODO: Support mulitple files
     System.err.println("This provider supports only one class at the moment.");
@@ -35,7 +37,7 @@ public final class KeyApplicant extends ExportAdapter {
     ContractLibAst ast = generator.generateFromPath(fileName);
     SimpleKeyProviderTranslator trans = new SimpleKeyProviderTranslator(messageManager);
     List<TranslationResult> results = trans.translateContractLibAstApplicant(ast);
-      
+
     return results;
   }
 }

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/KeyProvider.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/KeyProvider.java
@@ -4,13 +4,16 @@ import java.io.IOException;
 import java.util.List;
 import java.nio.file.Path;
 
+import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.ExportAdapter;
 import org.contract_lib.contract_chameleon.error.ChameleonMessageManager;
 
 import org.contract_lib.lang.contract_lib.ast.ContractLibAst;
 import org.contract_lib.lang.contract_lib.generator.ContractLibGenerator;
 
-//TODO: Subclase the correct export adapter
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class KeyProvider extends ExportAdapter {
 
   public String defaultOutputDir() {
@@ -23,8 +26,7 @@ public final class KeyProvider extends ExportAdapter {
 
   public List<TranslationResult> perform(
       List<Path> sourceFiles,
-      ChameleonMessageManager messageManager
-    ) throws IOException {
+      ChameleonMessageManager messageManager) throws IOException {
 
     //TODO: Support mulitple files
     System.err.println("This provider supports only one class at the moment.");
@@ -35,7 +37,7 @@ public final class KeyProvider extends ExportAdapter {
     ContractLibAst ast = generator.generateFromPath(fileName);
     SimpleKeyProviderTranslator trans = new SimpleKeyProviderTranslator(messageManager);
     List<TranslationResult> results = trans.translateContractLibAstProvider(ast);
-      
+
     return results;
   }
 }

--- a/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translations.FuncProvider
+++ b/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translations.FuncProvider
@@ -1,6 +1,0 @@
-org.contract_lib.adapters.translations.functions.BoolFuncTranslations
-org.contract_lib.adapters.translations.functions.IntFuncTranslations
-org.contract_lib.adapters.translations.functions.MapFuncTranslations
-org.contract_lib.adapters.translations.functions.SetFuncTranslations
-org.contract_lib.adapters.translations.functions.SeqFuncTranslations
-

--- a/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translations.TypeTranslation
+++ b/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translations.TypeTranslation
@@ -1,8 +1,0 @@
-org.contract_lib.adapters.translations.types.BoolTranslation
-org.contract_lib.adapters.translations.types.BoundedIntTranslation
-org.contract_lib.adapters.translations.types.IntTranslation
-org.contract_lib.adapters.translations.types.MapTranslation
-org.contract_lib.adapters.translations.types.RefTranslation
-org.contract_lib.adapters.translations.types.SeqTranslation
-org.contract_lib.adapters.translations.types.SetTranslation
-

--- a/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
+++ b/contract-chameleon.adapter.key.export/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
@@ -1,2 +1,0 @@
-org.contract_lib.adapters.KeyProvider
-org.contract_lib.adapters.KeyApplicant

--- a/contract-chameleon.adapter.key.import/build.gradle
+++ b/contract-chameleon.adapter.key.import/build.gradle
@@ -14,6 +14,10 @@ repositories {
 }
 
 dependencies {
+
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+
     implementation project(":contract-chameleon.core")
     implementation project(":contract-chameleon.error")
     implementation project(":contract-chameleon.lang.contract_lib")

--- a/contract-chameleon.adapter.key.import/src/main/java/org/contract_lib/adapters/KeyImportApplicant.java
+++ b/contract-chameleon.adapter.key.import/src/main/java/org/contract_lib/adapters/KeyImportApplicant.java
@@ -6,9 +6,13 @@ import java.util.List;
 
 import java.nio.file.Path;
 
+import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.ImportAdapter;
 import org.contract_lib.contract_chameleon.error.ChameleonMessageManager;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class KeyImportApplicant extends ImportAdapter {
 
   public String defaultOutputDir() {

--- a/contract-chameleon.adapter.key.import/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
+++ b/contract-chameleon.adapter.key.import/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
@@ -1,1 +1,0 @@
-org.contract_lib.adapters.KeyImportApplicant

--- a/contract-chameleon.adapter.verifast.export/build.gradle
+++ b/contract-chameleon.adapter.verifast.export/build.gradle
@@ -13,6 +13,9 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+
     implementation project(":contract-chameleon.core")
     implementation project(":contract-chameleon.error")
     implementation project(":contract-chameleon.lang.contract_lib")

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/VerifastApplicant.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/VerifastApplicant.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.util.List;
 import java.nio.file.Path;
 
+import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.ExportAdapter;
 import org.contract_lib.contract_chameleon.error.ChameleonMessageManager;
 
 import org.contract_lib.lang.contract_lib.ast.ContractLibAst;
 import org.contract_lib.lang.contract_lib.generator.ContractLibGenerator;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class VerifastApplicant extends ExportAdapter {
 
   public String defaultOutputDir() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/VerifastProvider.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/VerifastProvider.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.util.List;
 import java.nio.file.Path;
 
+import org.contract_lib.contract_chameleon.Adapter;
 import org.contract_lib.contract_chameleon.ExportAdapter;
 import org.contract_lib.contract_chameleon.error.ChameleonMessageManager;
 
 import org.contract_lib.lang.contract_lib.ast.ContractLibAst;
 import org.contract_lib.lang.contract_lib.generator.ContractLibGenerator;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(Adapter.class)
 public final class VerifastProvider extends ExportAdapter {
 
   public String defaultOutputDir() {

--- a/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translation.TermTranslationProvider
+++ b/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translation.TermTranslationProvider
@@ -1,5 +1,0 @@
-org.contract_lib.adapters.translation.functions.BooleanTermTranslation
-org.contract_lib.adapters.translation.functions.IntTermTranslation
-org.contract_lib.adapters.translation.functions.SeqTermTranslation
-org.contract_lib.adapters.translation.functions.SetTermTranslation
-org.contract_lib.adapters.translation.functions.MapTermTranslation

--- a/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translation.TypeTranslation
+++ b/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.adapters.translation.TypeTranslation
@@ -1,6 +1,0 @@
-org.contract_lib.adapters.translation.types.IntTranslation
-org.contract_lib.adapters.translation.types.BoolTranslation
-org.contract_lib.adapters.translation.types.SeqTranslation
-org.contract_lib.adapters.translation.types.SetTranslation
-org.contract_lib.adapters.translation.types.RefTranslation
-org.contract_lib.adapters.translation.types.MapTranslation

--- a/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
+++ b/contract-chameleon.adapter.verifast.export/src/main/resources/META-INF/services/org.contract_lib.contract_chameleon.Adapter
@@ -1,2 +1,0 @@
-org.contract_lib.adapters.VerifastApplicant
-org.contract_lib.adapters.VerifastProvider

--- a/contract-chameleon.cl/build.gradle
+++ b/contract-chameleon.cl/build.gradle
@@ -1,18 +1,5 @@
 plugins {
-    id 'application'
-
-    // Used to create a singel jar
-    id("com.gradleup.shadow") version "9.0.0-rc1"
-}
-
-shadowJar {
-    archiveClassifier.set("exe")
-    archiveBaseName.set("contract-chameleon")
-    mergeServiceFiles()
-}
-
-distZip {
-    archiveBaseName.set("contract-chameleon")
+  id 'java-library'
 }
 
 repositories {
@@ -28,12 +15,6 @@ repositories {
 dependencies {
     implementation project(":contract-chameleon.core")
 
-    // Add adapters to the final jar, might be still extended through classpath in `java -cp adapters/* org.contractlib.contract_chameleon.ContractChameleon`
-    runtimeOnly project(":contract-chameleon.adapter.key.export")
-    runtimeOnly project(":contract-chameleon.adapter.verifast.export")
-    runtimeOnly project(":contract-chameleon.adapter.key.import")
-    runtimeOnly project(":contract-chameleon.adapter.help")
-    
     // Use JUnit Jupiter for testing.
     testImplementation libs.junit.jupiter
     //testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
@@ -45,20 +26,4 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
-}
-
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
-application {
-    // Define the main class for the application.
-    mainClass = 'org.contract_lib.ContractChameleon'
-}
-
-jar {
-  manifest {
-    attributes 'Main-Class': application.mainClass
-  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-rootProject.name = 'Contract-Chameleon'
+rootProject.name = 'contract-chameleon'
 
 // Base Packages
 include('contract-chameleon.error')


### PR DESCRIPTION
Update assemble procedure to support new adapters easily

- Simplify build structure
  - add application in parent (instead of `cl` subprojcect)
  - add dependencies of the different adapters to root project
- Build `-all` and `-light` shadow JAR (with correct manifest files) 
- Add maven publish to work with the extension (required by extension template)
- Use @AutoService to not work with service files manually