### PR TITLE
Add missing adapter translations

### DIFF
--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/BoolFuncTranslations.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/BoolFuncTranslations.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 
 import org.contract_lib.adapters.translations.FuncProvider;
@@ -14,6 +15,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import static org.contract_lib.adapters.translations.FuncTranslation.UnaryTranslation;
 import static org.contract_lib.adapters.translations.FuncTranslation.BinaryTranslation;
 
+@AutoService(FuncProvider.class)
 public record BoolFuncTranslations() implements FuncProvider {
 
   static final Sort CLIB_BOOLEAN_TYPE = new Sort.Type("Bool");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/IntFuncTranslations.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/IntFuncTranslations.java
@@ -3,6 +3,7 @@ package org.contract_lib.adapters.translations.functions;
 import java.util.List;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 
 import org.contract_lib.adapters.translations.FuncProvider;
@@ -11,6 +12,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import static org.contract_lib.adapters.translations.FuncTranslation.BinaryTranslation;
 
+@AutoService(FuncProvider.class)
 public record IntFuncTranslations() implements FuncProvider {
 
   static final Sort CLIB_INT_TYPE = new Sort.Type("Int");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/MapFuncTranslations.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/MapFuncTranslations.java
@@ -3,6 +3,7 @@ package org.contract_lib.adapters.translations.functions;
 import java.util.List;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -18,6 +19,7 @@ import org.contract_lib.adapters.translations.FuncTranslation;
 import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.contract_lib.ast.Term;
 
+@AutoService(FuncProvider.class)
 public record MapFuncTranslations() implements FuncProvider {
 
   static final Sort CLIB_MAP_TYPE = new Sort.Type("Map");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/SeqFuncTranslations.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/SeqFuncTranslations.java
@@ -3,6 +3,7 @@ package org.contract_lib.adapters.translations.functions;
 import java.util.List;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -19,6 +20,7 @@ import org.contract_lib.adapters.translations.FuncTranslation;
 import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.contract_lib.ast.Term;
 
+@AutoService(FuncProvider.class)
 public record SeqFuncTranslations() implements FuncProvider {
 
   static final Sort CLIB_SEQ_TYPE = new Sort.Type("Seq");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/SetFuncTranslations.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/functions/SetFuncTranslations.java
@@ -3,6 +3,7 @@ package org.contract_lib.adapters.translations.functions;
 import java.util.List;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.ArrayAccessExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -18,6 +19,7 @@ import org.contract_lib.adapters.translations.FuncTranslation;
 import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.contract_lib.ast.Term;
 
+@AutoService(FuncProvider.class)
 public record SetFuncTranslations() implements FuncProvider {
 
   static final Sort CLIB_SET_TYPE = new Sort.Type("Set");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/BoolTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/BoolTranslation.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import com.github.javaparser.ast.expr.Expression;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 
 import org.contract_lib.adapters.translations.TypeTranslation;
@@ -13,6 +14,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class BoolTranslation implements TypeTranslation {
   public Sort getClibSort() {
     return new Sort.Type("Bool");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/BoundedIntTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/BoundedIntTranslation.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 
 import com.github.javaparser.ast.expr.SimpleName;
@@ -19,6 +20,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.key.ast.KeySort;
 
 //TODO: Yes, one could just use the correct math mode, but I kind of like this approach :)
+@AutoService(TypeTranslation.class)
 public class BoundedIntTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/IntTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/IntTranslation.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import com.github.javaparser.ast.expr.Expression;
 
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 
 import org.contract_lib.adapters.translations.TypeTranslation;
@@ -13,6 +14,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class IntTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/LogicTypeTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/LogicTypeTranslation.java
@@ -14,6 +14,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import org.contract_lib.adapters.translations.TypeTranslation;

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/MapTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/MapTranslation.java
@@ -21,6 +21,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
@@ -32,6 +33,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class MapTranslation implements TypeTranslation {
   public Sort getClibSort() {
     return new Sort.Type("Map");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/RefTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/RefTranslation.java
@@ -7,12 +7,14 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 
 import org.contract_lib.adapters.translations.TypeTranslation;
 import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class RefTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/SeqTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/SeqTranslation.java
@@ -21,6 +21,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
@@ -32,6 +33,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class SeqTranslation implements TypeTranslation {
   public Sort getClibSort() {
     return new Sort.Type("Seq");

--- a/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/SetTranslation.java
+++ b/contract-chameleon.adapter.key.export/src/main/java/org/contract_lib/adapters/translations/types/SetTranslation.java
@@ -21,6 +21,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.type.Type;
+import com.google.auto.service.AutoService;
 import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
@@ -32,6 +33,7 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 
 import org.contract_lib.lang.key.ast.KeySort;
 
+@AutoService(TypeTranslation.class)
 public class SetTranslation implements TypeTranslation {
   public Sort getClibSort() {
     return new Sort.Type("Set");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/BooleanTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/BooleanTermTranslation.java
@@ -10,10 +10,13 @@ import org.contract_lib.lang.contract_lib.ast.Symbol;
 
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
 import static org.contract_lib.adapters.translation.TermTranslation.UnaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.FixpointOperatorTranslation;
 
+@AutoService(TermTranslationProvider.class)
 public final record BooleanTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/IntTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/IntTermTranslation.java
@@ -10,9 +10,12 @@ import org.contract_lib.lang.contract_lib.ast.Symbol;
 
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
 import static org.contract_lib.adapters.translation.TermTranslation.UnaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperatorTranslation;
 
+@AutoService(TermTranslationProvider.class)
 public final record IntTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_INT = new Sort.Type("Int");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/MapTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/MapTermTranslation.java
@@ -11,10 +11,13 @@ import org.contract_lib.lang.contract_lib.ast.Symbol;
 
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
 import static org.contract_lib.adapters.translation.TermTranslation.UnaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.FixpointOperatorTranslation;
 
+@AutoService(TermTranslationProvider.class)
 public final record MapTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SeqTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SeqTermTranslation.java
@@ -12,12 +12,15 @@ import org.contract_lib.lang.contract_lib.ast.Symbol;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
 import static org.contract_lib.adapters.translation.TermTranslation.UnaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.FixpointOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.ConstantTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.VeriFastExpressionTranslation;
 
+@AutoService(TermTranslationProvider.class)
 public final record SeqTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SetTermTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/functions/SetTermTranslation.java
@@ -10,10 +10,13 @@ import org.contract_lib.lang.contract_lib.ast.Symbol;
 
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
 import static org.contract_lib.adapters.translation.TermTranslation.UnaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.BinaryOperatorTranslation;
 import static org.contract_lib.adapters.translation.TermTranslation.FixpointOperatorTranslation;
 
+@AutoService(TermTranslationProvider.class)
 public final record SetTermTranslation() implements TermTranslationProvider {
 
   public final static Sort.Type CLIB_BOOLEAN = new Sort.Type("Bool");

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/BoolTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/BoolTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class BoolTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/IntTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/IntTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class IntTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/MapTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/MapTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class MapTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/RefTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/RefTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class RefTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SeqTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SeqTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class SeqTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SetTranslation.java
+++ b/contract-chameleon.adapter.verifast.export/src/main/java/org/contract_lib/adapters/translation/types/SetTranslation.java
@@ -9,6 +9,9 @@ import org.contract_lib.lang.contract_lib.ast.Sort;
 import org.contract_lib.lang.verifast.ast.VeriFastExpression;
 import org.contract_lib.lang.verifast.ast.VeriFastType;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(TypeTranslation.class)
 public final class SetTranslation implements TypeTranslation {
 
   public Sort getClibSort() {

--- a/tests.integration/build.gradle
+++ b/tests.integration/build.gradle
@@ -1,3 +1,8 @@
+/*dependencies {
+   
+  runtimeOnly project(":contract-chameleon.adapter.verifast.export")
+  runtimeOnly project(":contract-chameleon.adapter.key.import")
+}*/
 
 ext.integrationTasks = []
 
@@ -9,7 +14,10 @@ def runIntegrationTest(String taskName, List<String> argList) {
         dependsOn "${appModule}:classes"
 
         def sub = project(appModule)
-        classpath = sub.sourceSets.main.runtimeClasspath
+        classpath = sub.sourceSets.main.runtimeClasspath +
+          project(":contract-chameleon.adapter.key.export").sourceSets.main.runtimeClasspath +
+          project(":contract-chameleon.adapter.key.import").sourceSets.main.runtimeClasspath +
+          project(":contract-chameleon.adapter.verifast.export").sourceSets.main.runtimeClasspath
         mainClass.set(sub.application.mainClass)
 
         args = argList


### PR DESCRIPTION
When switching to the simplified adapter plugin system, the adapter manifest of the translations was also deleted, leading to crashed.